### PR TITLE
Support for .NET 4.5 and VS2015 (32 and 64bit)

### DIFF
--- a/AssemblyUtils.cs
+++ b/AssemblyUtils.cs
@@ -50,4 +50,9 @@ internal static class AssemblyUtils {
     public static Version GetCLRVersion(Type type) {
         return new Version(Assembly.GetAssembly(type).ImageRuntimeVersion.TrimStart('v'));
     }
+
+    public static bool IsRunningAt32Bit() {
+        //easiest most performant way to detect
+        return IntPtr.Size == 4;
+    }
 }

--- a/PreSharp.cs
+++ b/PreSharp.cs
@@ -36,4 +36,8 @@ public static class PreSharp {
         }
         HasOutputs = true;
     }
+
+    public static void Install() {
+        PreSharpEntryPoint.Install();
+    }
 }

--- a/PreSharp.csproj
+++ b/PreSharp.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
@@ -12,7 +12,7 @@
     <AssemblyName>PreSharp</AssemblyName>
     <KeyContainerName>
     </KeyContainerName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SignAssembly>false</SignAssembly>
     <PublishUrl>publish\</PublishUrl>
@@ -34,8 +34,7 @@
     </StartupObject>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
-    <OldToolsVersion>3.5</OldToolsVersion>
-    <UpgradeBackupLocation />
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>
@@ -57,9 +56,13 @@
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Build.Framework" />
-    <Reference Include="Microsoft.Build.Utilities.v3.5">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
+    <Reference Include="Microsoft.Build.Framework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.Build.Framework.14.3.0\lib\net45\Microsoft.Build.Framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Build.Utilities.Core, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.Build.Utilities.Core.14.3.0\lib\net45\Microsoft.Build.Utilities.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">
@@ -87,6 +90,10 @@
   <ItemGroup>
     <EmbeddedResource Include="PreSharp.targets">
     </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/PreSharp.csproj
+++ b/PreSharp.csproj
@@ -36,7 +36,7 @@
     </FileUpgradeFlags>
     <TargetFrameworkProfile />
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -44,16 +44,18 @@
     <DefineConstants>TRACE;DEBUG;DISABLE_PRESHARP</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <PlatformTarget>x86</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE;DISABLE_PRESHARP</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <PlatformTarget>x86</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Build.Framework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/PreSharp.sln
+++ b/PreSharp.sln
@@ -3,16 +3,22 @@ Microsoft Visual Studio Solution File, Format Version 11.00
 # Visual Studio 2010
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PreSharp", "PreSharp.csproj", "{47E85B57-70FE-49DC-8807-22BED8A999DB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PreSharp32", "..\PreSharp32\PreSharp32.csproj", "{DCC73800-80EF-4A46-B2B2-E9131383DC8F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|x86 = Debug|x86
-		Release|x86 = Release|x86
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{47E85B57-70FE-49DC-8807-22BED8A999DB}.Debug|x86.ActiveCfg = Debug|x86
-		{47E85B57-70FE-49DC-8807-22BED8A999DB}.Debug|x86.Build.0 = Debug|x86
-		{47E85B57-70FE-49DC-8807-22BED8A999DB}.Release|x86.ActiveCfg = Release|x86
-		{47E85B57-70FE-49DC-8807-22BED8A999DB}.Release|x86.Build.0 = Release|x86
+		{47E85B57-70FE-49DC-8807-22BED8A999DB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{47E85B57-70FE-49DC-8807-22BED8A999DB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{47E85B57-70FE-49DC-8807-22BED8A999DB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{47E85B57-70FE-49DC-8807-22BED8A999DB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DCC73800-80EF-4A46-B2B2-E9131383DC8F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DCC73800-80EF-4A46-B2B2-E9131383DC8F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DCC73800-80EF-4A46-B2B2-E9131383DC8F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DCC73800-80EF-4A46-B2B2-E9131383DC8F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/PreSharp.targets
+++ b/PreSharp.targets
@@ -76,7 +76,7 @@
         </PreSharpBuildTask>
         <WriteLinesToFile File="PreSharp.CompileGeneratedFiles.cache" Lines="@(CompileGeneratedFiles)" Overwrite="true" />
         <WriteLinesToFile File="PreSharp.EmbeddedResourceGeneratedFiles.cache" Lines="@(EmbeddedResourceGeneratedFiles)" Overwrite="true" />
-        <Delete Files="@(FilesToDelete)" />
+        <Delete Files="@(FilesToDelete)" TreatErrorsAsWarnings="true"/>
     </Target>
 
     <Target Name="PreSharpAddCompileGeneratedFilesTarget">

--- a/PreSharpEntryPoint.cs
+++ b/PreSharpEntryPoint.cs
@@ -6,16 +6,34 @@ using System.Reflection;
 using System.Xml.Linq;
 using Microsoft.Win32;
 using System.Text.RegularExpressions;
+using System.Globalization;
 
 internal sealed class PreSharpEntryPoint {
+
+    private static readonly string ProgramFilesPath = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
 
     private static int Main(string[] args) {
 
         try {
+            bool isInstall = args.Length == 0;
+            bool force64Install = false;
+            if (args.Length == 1) {
+                force64Install = args[0].Trim('/', '-') == "x64";
+                isInstall |= force64Install;
+            }
 
-            if (args.Length == 0) {
+            if (isInstall)  {
+                if (!AssemblyUtils.IsRunningAt32Bit()) {
+                    Console.WriteLine();
+                    LaunchInstallIn32Bits();
+                }
+                
+                if (AssemblyUtils.IsRunningAt32Bit() || force64Install) {
+                    
+                    Console.WriteLine();
+                    Install();
+                }
 
-                Install();
                 return 0;
 
             } else {
@@ -57,13 +75,14 @@ internal sealed class PreSharpEntryPoint {
         }
     }
 
-    private static void Install() {
+    public static void Install() {
+        
+        Console.WriteLine("Installing PreSharp in " + (AssemblyUtils.IsRunningAt32Bit() ? "32" : "64") + "bits.");
 
-        string programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
-        string preSharpDir = Path.Combine(programFiles, "PreSharp");
+        string preSharpDir = Path.Combine(ProgramFilesPath, "PreSharp");
         string preSharpTargetsFile = Path.Combine(preSharpDir, "PreSharp.targets");
         string preSharpExecutable = Path.Combine(preSharpDir, "PreSharp.exe");
-        var versionsDic = new Dictionary<string, string> { { "v3.5", "9.0" }, { "v4.0", "10.0" } };
+        var versionsDic = new Dictionary<string, string[]> { { "v3.5", new String[] { "9.0" } }, { "v4.0", new String[] { "10.0", "11.0", "12.0", "14.0" } } };
 
         //Setup PreSharp
         Directory.CreateDirectory(preSharpDir);
@@ -77,10 +96,6 @@ internal sealed class PreSharpEntryPoint {
 
         //For each .net version
         foreach (var version in versionsDic) {
-            string msBuildExtensionsDir = Path.Combine(programFiles, @"MsBuild\" + version.Key);
-            string customAfterMicrosoftCommonTargetsFile = Path.Combine(msBuildExtensionsDir, "Custom.After.Microsoft.Common.targets");
-            string visualStudioKeyPath = @"SOFTWARE\Microsoft\VisualStudio\" + version.Value;
-
             //They dont seem to decide where to keep the stuff...
             string[] dotNetKeyPaths = new string[] { @"SOFTWARE\Microsoft\NET Framework Setup\NDP\" + version.Key,
                                                      @"SOFTWARE\Microsoft\NET Framework Setup\NDP\" + version.Key.Substring(0, Math.Max(version.Key.LastIndexOf('.'), 0)) + @"\Full\" };
@@ -98,48 +113,103 @@ internal sealed class PreSharpEntryPoint {
                 continue;
             }
 
-            //Setup MSBUILD
-            Directory.CreateDirectory(msBuildExtensionsDir);
+            CreateCustomTargets(version.Key);
 
-            XElement import = new XElement(XName.Get("Import", string.Empty),
-                        new XAttribute("Project", @"$(ProgramFiles)\PreSharp\PreSharp.targets"),
-                        new XAttribute("Condition", @" Exists('$(ProgramFiles)\PreSharp\PreSharp.targets') and Exists('$(ProgramFiles)\PreSharp\PreSharp.exe') and '$(DISABLE_PRESHARP)' == '' "));
+            string installedVsString = string.Empty;
+            foreach (var vsVersion in version.Value) {
+                string visualStudioKeyPath = @"SOFTWARE\Microsoft\VisualStudio\" + vsVersion;
+                //Setup VS
+                using (var vsKey = Registry.LocalMachine.OpenSubKey(visualStudioKeyPath, false)) {
+                    if (vsKey != null && vsKey.GetValue("InstallDir") != null) {
 
-            XElement project;
-            if (!File.Exists(customAfterMicrosoftCommonTargetsFile)) {
-                project = new XElement("Project", import);
-            } else {
-                project = XElement.Parse(Regex.Replace(File.ReadAllText(customAfterMicrosoftCommonTargetsFile), @"<Project\s*xmlns\s*=\s*""http://[^""]*""\s*>", "<Project>"));
-                if (!project.Elements("Import").Attributes("Project").Where(attr => attr.Value == @"$(ProgramFiles)\PreSharp\PreSharp.targets").Any()) {
-                    project.Add(import);
-                }
-            }
-            File.WriteAllText(customAfterMicrosoftCommonTargetsFile, project.ToString().Replace("<Project>", "<Project xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\">"));
-
-            //Setup VS
-            bool installedInVs = false;
-            using (var vsKey = Registry.LocalMachine.OpenSubKey(visualStudioKeyPath, false)) {
-                if (vsKey != null && vsKey.GetValue("InstallDir") != null) {
-
-                    using (var key = Registry.LocalMachine.OpenSubKey(visualStudioKeyPath + @"\MSBuild\SafeImports", true)) {
-                        if (key != null) {
-                            key.SetValue("PreSharp", preSharpTargetsFile);
+                        if (float.Parse(vsVersion, CultureInfo.InvariantCulture) >= 12) {
+                            CreateCustomTargets("v" + vsVersion);
                         }
-                    }
 
-                    using (var key = Registry.LocalMachine.OpenSubKey(visualStudioKeyPath + @"\Languages\File Extensions\.cst", true)) {
-                        if (key == null) {
-                            using (var newKey = Registry.LocalMachine.OpenSubKey(visualStudioKeyPath + @"\Languages\File Extensions", true).CreateSubKey(".cst")) {
-                                newKey.SetValue(null, "{694DD9B6-B865-4C5B-AD85-86356E9C88DC}");
+                        using (var key = Registry.LocalMachine.OpenSubKey(visualStudioKeyPath + @"\MSBuild\SafeImports", true)) {
+                            if (key != null) {
+                                key.SetValue("PreSharp", preSharpTargetsFile);
                             }
                         }
-                    }
 
-                    installedInVs = true;
+                        using (var key = Registry.LocalMachine.OpenSubKey(visualStudioKeyPath + @"\Languages\File Extensions\.cst", true)) {
+                            if (key == null) {
+                                using (var newKey = Registry.LocalMachine.OpenSubKey(visualStudioKeyPath + @"\Languages\File Extensions", true).CreateSubKey(".cst")) {
+                                    newKey.SetValue(null, "{694DD9B6-B865-4C5B-AD85-86356E9C88DC}");
+                                }
+                            }
+                        }
+
+                        installedVsString += " (VS " + vsVersion + ")";
+                    }
                 }
             }
 
-            Console.WriteLine("PreSharp " + AssemblyUtils.GetVersion().ToString() + " was successfully installed in .net " + version.Key + (installedInVs ? "" : " (no Visual Studio)"));
+            Console.WriteLine("PreSharp " + AssemblyUtils.GetVersion().ToString() + " was successfully installed in .net " + version.Key + (installedVsString == string.Empty? " (no Visual Studio)" : installedVsString));
+        }
+    }
+
+    private static void CreateCustomTargets(string version) {
+        string msBuildExtensionsDir = Path.Combine(ProgramFilesPath, @"MsBuild\" + version);
+        string customAfterMicrosoftCommonTargetsFile = Path.Combine(msBuildExtensionsDir, "Custom.After.Microsoft.Common.targets");
+
+        //Setup MSBUILD
+        Directory.CreateDirectory(msBuildExtensionsDir);
+
+        XElement import = new XElement(XName.Get("Import", string.Empty),
+                    new XAttribute("Project", @"$(ProgramFiles)\PreSharp\PreSharp.targets"),
+                    new XAttribute("Condition", @" Exists('$(ProgramFiles)\PreSharp\PreSharp.targets') and Exists('$(ProgramFiles)\PreSharp\PreSharp.exe') and '$(DISABLE_PRESHARP)' == '' "));
+
+        XElement project;
+        if (!File.Exists(customAfterMicrosoftCommonTargetsFile)) {
+            project = new XElement("Project", import);
+        } else {
+            project = XElement.Parse(Regex.Replace(File.ReadAllText(customAfterMicrosoftCommonTargetsFile), @"<Project\s*xmlns\s*=\s*""http://[^""]*""\s*>", "<Project>"));
+            if (!project.Elements("Import").Attributes("Project").Where(attr => attr.Value == @"$(ProgramFiles)\PreSharp\PreSharp.targets").Any()) {
+                project.Add(import);
+            }
+        }
+        File.WriteAllText(customAfterMicrosoftCommonTargetsFile, project.ToString().Replace("<Project>", "<Project xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\">"));
+    }
+
+    private static void LaunchInstallIn32Bits() {
+        if (AssemblyUtils.IsRunningAt32Bit()) {
+            return; // No need, already running at 32bits
+        }
+
+        if (File.Exists("PreSharp32.exe")) {
+            System.Diagnostics.Process process = new System.Diagnostics.Process();
+            process.StartInfo = new System.Diagnostics.ProcessStartInfo("PreSharp32.exe");
+            process.StartInfo.UseShellExecute = false;
+            process.StartInfo.CreateNoWindow = true;
+            process.StartInfo.RedirectStandardOutput = true;
+            process.StartInfo.RedirectStandardError = true;
+            process.Start();
+            
+            try {
+                if (!process.WaitForExit(15000)) {
+                    Console.Error.WriteLine("Failed to install PreSharp in 32 bits. Timeout.");
+                    process.Kill();
+                    return;
+                }
+            } catch { }
+
+            string output = (process.StandardOutput.ReadToEnd() ?? string.Empty).Trim();
+            if (!string.IsNullOrEmpty(output)) {
+                Console.WriteLine(output);
+            }
+
+            string errors = (process.StandardError.ReadToEnd() ?? string.Empty).Trim();
+            if (!string.IsNullOrEmpty(errors)) {
+                Console.WriteLine(errors);
+            }
+
+            if (string.IsNullOrEmpty(errors) && string.IsNullOrEmpty(output)) {
+                Console.Error.WriteLine("Failed to install PreSharp in 32 bits. No output from process.");
+            }
+
+        } else {
+            Console.Error.WriteLine("Failed to install PreSharp in 32 bits. PreSharp32.exe was not found.");
         }
     }
 

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -14,5 +14,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(true)]
 [assembly: CLSCompliantAttribute(false)]
 
-[assembly: AssemblyVersion("1.3.4.3")]
-[assembly: AssemblyFileVersion("1.3.4.3")]
+[assembly: AssemblyVersion("1.3.5.0")]
+[assembly: AssemblyFileVersion("1.3.5.0")]

--- a/app.config
+++ b/app.config
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup></configuration>

--- a/packages.config
+++ b/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Build.Framework" version="14.3.0" targetFramework="net452" />
+  <package id="Microsoft.Build.Utilities.Core" version="14.3.0" targetFramework="net452" />
+</packages>


### PR DESCRIPTION
For compatibility, still installs by default on 32bit installation.

Installing in 64bit can be done running `presharp /x64`.
